### PR TITLE
Specify non-empty-array types

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -66,7 +66,7 @@ class Operation
      * @psalm-param int<1,max> $times
      * @psalm-param int<1,8> $roundingMode
      * @psalm-param int<1,max> $tries
-     * @return Money[]
+     * @psalm-return non-empty-array<Money>
      * @throws InvalidOperationException
      */
     public function split(int $times, int $roundingMode = Money::ROUND_HALF_UP, int $tries = 10): array
@@ -77,7 +77,7 @@ class Operation
             throw new InvalidOperationException(sprintf('$times must be >= 1, %d given', $times));
         }
 
-        /** @psalm-var Money[] $parts */
+        /** @psalm-var non-empty-array<Money> $parts */
         $parts = array_fill(0, $times, $part = $this->money->divide($times, $roundingMode));
 
         while (!$this->assertSplit($parts)) {
@@ -100,11 +100,12 @@ class Operation
     }
 
     /**
-     * @param Money[] $parts
+     * @psalm-param non-empty-array<Money> $parts
      * @throws InvalidOperationException
      */
     public static function join(array $parts): Money
     {
+        /** @phpstan-ignore-next-line */
         if (empty($parts)) {
             throw new InvalidOperationException('$parts array cannot be empty');
         }
@@ -125,7 +126,7 @@ class Operation
     }
 
     /**
-     * @param Money[] $parts
+     * @psalm-param non-empty-array<Money> $parts
      * @throws InvalidOperationException
      */
     public function assertSplit(array $parts): bool
@@ -134,7 +135,7 @@ class Operation
     }
 
     /**
-     * @param Money[] $parts
+     * @psalm-param non-empty-array<Money> $parts
      * @throws InvalidOperationException
      */
     public static function average(array $parts): Money

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -89,11 +89,10 @@ class OperationTest extends TestCase
     /**
      * @dataProvider splitProvider
      *
-     * @param Money[] $expectedParts
+     * @psalm-param non-empty-array<Money> $expectedParts
      */
     public function test_split(Money $originalMoney, array $expectedParts): void
     {
-        /** @psalm-var int<1,max> $times */
         $times = count($expectedParts);
 
         $this->assertCount($times, $result = Operation::of($originalMoney)->split($times));
@@ -124,7 +123,7 @@ class OperationTest extends TestCase
     /**
      * @dataProvider splitProvider
      *
-     * @param Money[] $parts
+     * @psalm-param non-empty-array<Money> $parts
      */
     public function test_join(Money $originalMoney, array $parts): void
     {
@@ -142,7 +141,7 @@ class OperationTest extends TestCase
     {
         $this->expectException(InvalidOperationException::class);
 
-        Operation::join([]);
+        Operation::join([]); // @phpstan-ignore-line
     }
 
     public function test_split_exception_indivisible(): void
@@ -157,7 +156,7 @@ class OperationTest extends TestCase
     /**
      * @dataProvider splitProvider
      *
-     * @param Money[] $expectedParts
+     * @psalm-param non-empty-array<Money> $expectedParts
      */
     public function test_assert_split(Money $originalMoney, array $expectedParts): void
     {
@@ -167,7 +166,7 @@ class OperationTest extends TestCase
     /**
      * @dataProvider averageProvider
      *
-     * @param Money[] $parts
+     * @psalm-param non-empty-array<Money> $parts
      */
     public function test_assert_average(array $parts, Money $expectedMoney): void
     {
@@ -239,7 +238,7 @@ class OperationTest extends TestCase
     {
         $this->expectException(InvalidOperationException::class);
 
-        Operation::average([]);
+        Operation::average([]); // @phpstan-ignore-line
     }
 
     /**
@@ -279,7 +278,7 @@ class OperationTest extends TestCase
     }
 
     /**
-     * @psalm-return array<array{Money, Money[]}>
+     * @psalm-return array<array{Money, non-empty-array<Money>}>
      */
     public static function splitProvider(): array
     {
@@ -293,7 +292,7 @@ class OperationTest extends TestCase
     }
 
     /**
-     * @psalm-return array<array{Money[], Money}>
+     * @psalm-return array<array{non-empty-array<Money>, Money}>
      */
     public static function averageProvider(): array
     {


### PR DESCRIPTION
Use [Psalm's non-empty-array](https://psalm.dev/docs/annotating_code/type_syntax/array_types/#non-empty-array) notation to specify array parameters that must not be empty.